### PR TITLE
feat: add title and description editing in republish modal

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -17,23 +17,24 @@ Installez directement depuis le [Chrome Web Store](https://chromewebstore.google
 ### Option 2 : Depuis les sources
 
 1. Clonez ce dépôt ou téléchargez-le en tant que ZIP
-2. Ouvrez Chrome et allez sur `chrome://extensions`
-3. Activez le "Mode développeur" en haut à droite
-4. Cliquez sur "Charger l'extension non empaquetée" et sélectionnez le dossier de l'extension
-5. Rendez-vous sur votre [tableau de bord Leboncoin](https://www.leboncoin.fr/compte/part/mes-annonces)
+2. Exécutez `npm install && npm run build`
+3. Ouvrez Chrome et allez sur `chrome://extensions`
+4. Activez le "Mode développeur" en haut à droite
+5. Cliquez sur "Charger l'extension non empaquetée" et sélectionnez le dossier `dist/`
+6. Rendez-vous sur votre [tableau de bord Leboncoin](https://www.leboncoin.fr/compte/part/mes-annonces)
 
 ## 📖 Utilisation
 
 1. Rendez-vous sur votre [tableau de bord Leboncoin](https://www.leboncoin.fr/compte/part/mes-annonces)
 2. Cliquez sur le bouton **✨ Republier** à côté de n'importe quelle annonce
-3. Modifiez le prix si nécessaire (ou conservez le prix actuel)
-4. Confirmez l'action
+3. Modifiez le titre, la description et/ou le prix dans la modale
+4. Cliquez sur **✨ Republier** pour confirmer
 5. Attendez que le processus de republication automatique se termine
 
 L'extension va :
 - ✅ Supprimer votre ancienne annonce
 - ✅ Créer une nouvelle annonce avec le même contenu
-- ✅ Mettre à jour le prix si vous l'avez modifié
+- ✅ Appliquer vos modifications au titre, à la description ou au prix
 - ✅ Actualiser le tableau de bord pour afficher la nouvelle annonce
 
 ## 📝 Licence

--- a/README.md
+++ b/README.md
@@ -17,23 +17,24 @@ Install directly from the [Chrome Web Store](https://chromewebstore.google.com/d
 ### Option 2: From Source
 
 1. Clone this repository or download it as a ZIP
-2. Open Chrome and go to `chrome://extensions`
-3. Enable "Developer mode" in the top right
-4. Click "Load unpacked" and select the extension folder
-5. Go to your [Leboncoin dashboard](https://www.leboncoin.fr/compte/part/mes-annonces)
+2. Run `npm install && npm run build`
+3. Open Chrome and go to `chrome://extensions`
+4. Enable "Developer mode" in the top right
+5. Click "Load unpacked" and select the `dist/` folder
+6. Go to your [Leboncoin dashboard](https://www.leboncoin.fr/compte/part/mes-annonces)
 
 ## 📖 Usage
 
 1. Go to your [Leboncoin dashboard](https://www.leboncoin.fr/compte/part/mes-annonces)
 2. Click the **✨ Republish** button next to any ad
-3. Update the price if needed (or keep the current price)
-4. Confirm the action
+3. Edit the title, description, and/or price in the modal
+4. Click **✨ Republier** to confirm
 5. Wait for the automatic republishing process to complete
 
 The extension will:
 - ✅ Delete your old ad
 - ✅ Create a new ad with the same content
-- ✅ Update the price if you modified it
+- ✅ Apply any edits to the title, description, or price
 - ✅ Refresh the dashboard to display the new ad
 
 ## 📝 License

--- a/src/ui.js
+++ b/src/ui.js
@@ -12,34 +12,181 @@ import { CONFIG } from './config.js';
 // USER INTERACTION
 // ============================================================================
 
-const promptForNewPrice = (currentPrice) => {
-  const pricePrompt = `Prix actuel: ${currentPrice} €\n\nEntrez le nouveau prix (en euros) ou laissez vide pour garder le prix actuel:`;
-  const input = prompt(pricePrompt, currentPrice);
+const fieldStyle = `
+  width: 100%;
+  box-sizing: border-box;
+  background: #1e2024;
+  color: #e4e4e7;
+  border: 1px solid #3f4147;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 13px;
+  outline: none;
+  margin-top: 4px;
+`;
 
-  if (input === null) {
-    return null;
-  }
+const labelStyle = `
+  display: block;
+  color: #a1a1aa;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 14px;
+`;
 
-  if (input.trim() === '') {
-    return currentPrice;
-  }
+const showEditModal = (adData) => new Promise((resolve) => {
+  const overlay = document.createElement('div');
 
-  const newPrice = parseFloat(input.trim());
+  overlay.style.cssText = `
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    z-index: 999998;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  `;
 
-  if (isNaN(newPrice) || newPrice <= 0) {
-    throw new Error('Prix invalide. Veuillez entrer un nombre positif.');
-  }
+  const card = document.createElement('div');
 
-  return newPrice;
-};
+  card.style.cssText = `
+    background: #2b2d31;
+    color: #e4e4e7;
+    padding: 20px 24px;
+    border-radius: 8px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.5);
+    border-left: 3px solid #ff8a4a;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    font-size: 13px;
+    width: 480px;
+    max-width: 90vw;
+  `;
 
-const confirmRepublish = (adData) => confirm(
-  '✅ Prêt à republier:\n\n' +
-    `📋 ${adData.subject}\n` +
-    `💰 ${adData.price} €\n` +
-    `📁 ${adData.category_name}\n\n` +
-    'Lancer la republication automatique?'
-);
+  const title = document.createElement('div');
+
+  title.style.cssText = 'font-weight: 600; font-size: 14px; margin-bottom: 4px;';
+  title.textContent = 'Modifier l\'annonce';
+
+  const labelSubject = document.createElement('label');
+
+  labelSubject.style.cssText = labelStyle;
+  labelSubject.textContent = 'Titre';
+
+  const inputSubject = document.createElement('input');
+
+  inputSubject.type = 'text';
+  inputSubject.value = adData.subject;
+  inputSubject.style.cssText = fieldStyle;
+
+  const labelBody = document.createElement('label');
+
+  labelBody.style.cssText = labelStyle;
+  labelBody.textContent = 'Description';
+
+  const inputBody = document.createElement('textarea');
+
+  inputBody.value = adData.body;
+  inputBody.rows = 5;
+  inputBody.style.cssText = fieldStyle + 'resize: vertical;';
+
+  const labelPrice = document.createElement('label');
+
+  labelPrice.style.cssText = labelStyle;
+  labelPrice.textContent = 'Prix (€)';
+
+  const inputPrice = document.createElement('input');
+
+  inputPrice.type = 'number';
+  inputPrice.min = '0';
+  inputPrice.step = '1';
+  inputPrice.value = adData.price;
+  inputPrice.style.cssText = fieldStyle;
+
+  const errorMsg = document.createElement('div');
+
+  errorMsg.style.cssText = `
+    color: #ef4444;
+    font-size: 12px;
+    margin-top: 10px;
+    min-height: 16px;
+  `;
+
+  const btnRow = document.createElement('div');
+
+  btnRow.style.cssText = 'display: flex; gap: 8px; margin-top: 16px; justify-content: flex-end;';
+
+  const btnCancel = document.createElement('button');
+
+  btnCancel.type = 'button';
+  btnCancel.textContent = 'Annuler';
+  btnCancel.style.cssText = `
+    background: #3f4147;
+    color: #e4e4e7;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  `;
+
+  const btnSubmit = document.createElement('button');
+
+  btnSubmit.type = 'button';
+  btnSubmit.textContent = '✨ Republier';
+  btnSubmit.style.cssText = `
+    background: linear-gradient(135deg, #ff8a4a 0%, #ec5a13 100%);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  `;
+
+  const close = (result) => { overlay.remove(); resolve(result); };
+
+  btnCancel.addEventListener('click', () => close(null));
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(null); });
+
+  btnSubmit.addEventListener('click', () => {
+    const subject = inputSubject.value.trim();
+    const body = inputBody.value;
+    const price = parseFloat(inputPrice.value);
+
+    if (!subject) {
+      errorMsg.textContent = 'Le titre ne peut pas être vide.';
+      return;
+    }
+
+    if (isNaN(price) || price <= 0) {
+      errorMsg.textContent = 'Prix invalide. Veuillez entrer un nombre positif.';
+      return;
+    }
+
+    close({ subject, body, price });
+  });
+
+  btnRow.appendChild(btnCancel);
+  btnRow.appendChild(btnSubmit);
+
+  card.appendChild(title);
+  card.appendChild(labelSubject);
+  card.appendChild(inputSubject);
+  card.appendChild(labelBody);
+  card.appendChild(inputBody);
+  card.appendChild(labelPrice);
+  card.appendChild(inputPrice);
+  card.appendChild(errorMsg);
+  card.appendChild(btnRow);
+
+  overlay.appendChild(card);
+  document.body.appendChild(overlay);
+  inputSubject.focus();
+});
 
 // ============================================================================
 // REPUBLISH WORKFLOW
@@ -56,22 +203,15 @@ const handleRepublishClick = async (listId) => {
 
     loadingNotif.remove();
 
-    const newPrice = promptForNewPrice(adData.price);
+    const edits = await showEditModal(adData);
 
-    if (newPrice === null) {
+    if (edits === null) {
       captureMessage('Republish cancelled by user', LEVELS.info);
 
       return;
     }
 
-    const updatedAdData = { ...adData, price: newPrice };
-
-    if (!confirmRepublish(updatedAdData)) {
-      console.log('Republication annulée');
-      captureMessage('Republish cancelled by user confirmation', LEVELS.info);
-
-      return;
-    }
+    const updatedAdData = { ...adData, ...edits };
 
     const publishingNotif = NotificationManager.show(NotificationManager.publishing());
     const adId = await createAdViaAPI(updatedAdData);


### PR DESCRIPTION
Replace native prompt/confirm dialogs with a custom modal that lets users edit the title, description, and price before republishing.                                                                            
                                                                                                                                                                                                                   
  - Remove `promptForNewPrice` and `confirmRepublish`                                                                                                                                                              
  - Add `showEditModal(adData)` returning a Promise with `{ subject, body, price }`                                                                                                                                
  - Pre-fills all fields from existing ad data                                                                                                                                                                     
  - Inline validation (non-empty title, positive price)                                                                                                                                                            
  - Styled to match the existing dark theme                                                                                                                                                                        
  - Update README (EN/FR) with build steps and new usage description     